### PR TITLE
Fixed white screen on 4K computer

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 
 window/size/width=480
 window/size/height=720
+window/dpi/allow_hidpi=true
 
 [rendering]
 


### PR DESCRIPTION
I fixed the white screen when starting the game on the 4k computer.

Changes:
* added the allow_hdpi setting to the project